### PR TITLE
add fairscale to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ipython==8.6.0
 seaborn==0.12.1
 tensorflow
 open_clip_torch
+fairscale

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ seaborn==0.12.1
 tensorflow
 open_clip_torch
 fairscale
+ultralytics


### PR DESCRIPTION
This appears to be a requirement of this extension; I'm not sure if there's a reason it was left out of requirements.txt

Additionally, I was getting a requirement of beautifulsoup4 (bs4) but couldn't track down where it was coming from. Perhaps that should be here as well?